### PR TITLE
update log to use kv_unstable_std instead of std

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ futures-timer = "3.0.1"
 localghost-macros = { path = "localghost-macros", version = "0.1.0" }
 js-sys = "0.3.35"
 kv-log-macro = "1.0.4"
-log = { version = "0.4.8", features = ["kv_unstable", "std"] }
+log = { version = "0.4.13", features = ["kv_unstable_std"] }
 wasm-bindgen = { version = "0.2.58", features = ["serde-serialize"] }
 wasm-bindgen-futures = "0.4.8"
 wasm-bindgen-test = "0.3.8"


### PR DESCRIPTION
Part of https://github.com/rust-lang/log/issues/437

The `log` crate has an unstable structured logging API under the `kv_unstable` feature. In previous releases, if you specified both the `kv_unstable` and `std` features of `log` like so:

```toml
log = { features = ["std", "kv_unstable"]}
```

you'd get support for standard library types in `log`'s structured logging API.

Going forward, this functionality is now gated under `kv_unstable_std`:

```toml
log = { features = ["kv_unstable_std"]}
```

This change was made because we need to enable features in optional dependencies when both the `std` and `kv_unstable` features are enabled, which isn't currently supported by Cargo.

This PR updates this library to follow the new approach. It can be merged at any time and is currently non-blocking, but on 2020-01-18 the version of `log` requiring `kv_unstable_std` instead of `kv_unstable` and `std` will be published.

Thanks for trying out `log`'s structured logging API and sorry for any disruption! :bow: