### PR TITLE
fix examples link in docs to point to mild-times/localghost directory

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,7 +26,7 @@
 //!
 //! For more examples see the [examples] directory.
 //!
-//! [examples]: https://github.com/yoshuawuyts/mild/tree/master/examples
+//! [examples]: https://github.com/mild-times/localghost/tree/main/examples
 //!
 //! # Getting started
 //!


### PR DESCRIPTION
Quick little fix so examples url in docs points to the right place.